### PR TITLE
Fix typos and texts

### DIFF
--- a/GasStove/GasStove.lua
+++ b/GasStove/GasStove.lua
@@ -26,26 +26,26 @@ end
 local doorSymbolPlace = Placement3D(Point3D(0, -depth / 2, height / 4),
                                     Vector3D(0, -1, 0), Vector3D(1, 0, 0))
 
--- Function creates a symbol representing a cooking surface with 4 rings 
+-- Function creates a symbol representing a cooking surface with 4 circles and rectangle 
 function MakeCookingSurfaceSymbol()
     -- Diameter is equal to 120, see technical task drawing
     local radius = 120 / 2
     local x = width / 4
     local y = depth / 4
-    -- Create rings
-    local ring1 = CreateCircle2D(Point2D(x, y), radius)
-    local ring2 = CreateCircle2D(Point2D(x, -y), radius)
-    local ring3 = CreateCircle2D(Point2D(-x, -y), radius)
-    local ring4 = CreateCircle2D(Point2D(-x, y), radius)
+    -- Create circles
+    local circle1 = CreateCircle2D(Point2D(x, y), radius)
+    local circle2 = CreateCircle2D(Point2D(x, -y), radius)
+    local circle3 = CreateCircle2D(Point2D(-x, -y), radius)
+    local circle4 = CreateCircle2D(Point2D(-x, y), radius)
     -- Create rectangle for symbolic geometry   
     local rectangle = CreateRectangle2D(Point2D(0, 0), 0, width,
                                         depth)
     -- Create geometry set
     local geometrySet = GeometrySet2D()
-    geometrySet:AddCurve(ring1)
-    geometrySet:AddCurve(ring2)
-    geometrySet:AddCurve(ring3)
-    geometrySet:AddCurve(ring4)
+    geometrySet:AddCurve(circle1)
+    geometrySet:AddCurve(circle2)
+    geometrySet:AddCurve(circle3)
+    geometrySet:AddCurve(circle4)
     geometrySet:AddCurve(rectangle)
     -- Return the resulting symbol
     return geometrySet

--- a/OutdoorAirConditionerUnit/OutdoorAirConditionerUnit.json
+++ b/OutdoorAirConditionerUnit/OutdoorAirConditionerUnit.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "defaultName": "External Air Conditioner Unit",
-    "description": "White parallelepiped on the facade of the house, sometimes dripping water on the head",
+    "defaultName": "Outdoor air conditioner unit",
+    "description": "Equipment",
     "version": "1.0.0",
     "author": "Renga Software"
   },
@@ -48,7 +48,7 @@
         },
         {
           "name": "PlateWidth",
-          "text": "Mounting plate width",
+          "text": "Plate width",
           "type": "Length",
           "default": 30,
           "min": 1,
@@ -56,7 +56,7 @@
         },
         {
           "name": "PlateDepth",
-          "text": "Mounting plate depth",
+          "text": "Plate depth",
           "type": "Length",
           "default": 350,
           "min": 1,
@@ -64,7 +64,7 @@
         },
         {
           "name": "PlateHeight",
-          "text": "Mounting plate height",
+          "text": "Plate height",
           "type": "Length",
           "default": 10,
           "min": 1,
@@ -72,7 +72,7 @@
         },
         {
           "name": "LeftPlateOffset",
-          "text": "Offset of the left mounting plate widthwise",
+          "text": "Left plate offset",
           "type": "Length",
           "default": 100,
           "min": 0,
@@ -80,7 +80,7 @@
         },
         {
           "name": "RightPlateOffset",
-          "text": "Offset of the right mounting plate widthwise",
+          "text": "Right plate offset",
           "type": "Length",
           "default": 700,
           "min": 0,
@@ -171,7 +171,7 @@
           "name": "NominalDiameter",
           "text": "Nominal diameter",
           "type": "Length",
-          "default": 10,
+          "default": 7,
           "min": 1,
           "max": 100000
         },
@@ -201,13 +201,13 @@
           "text": "Connection type",
           "type": "CoreEnum",
           "coreEnumType": "PipeConnectorType",
-          "default": "Compressed"
+          "default": "Socket"
         },
         {
           "name": "NominalDiameter",
           "text": "Nominal diameter",
           "type": "Length",
-          "default": 10,
+          "default": 20,
           "min": 1,
           "max": 100000
         },
@@ -217,14 +217,6 @@
           "type": "CoreEnum",
           "coreEnumType": "PipeThreadSize",
           "default": "D0_50"
-        },
-        {
-          "name": "Diameter",
-          "text": "Outer diameter",
-          "type": "Length",
-          "default": 10,
-          "min": 1,
-          "max": 100000
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Style templates of engineering system objects:
 - [Non-Return Damper](https://github.com/RengaSoftware/StyleTemplateSamples/tree/master/NonReturnDamper)
 - [Two Plane Cross](https://github.com/RengaSoftware/StyleTemplateSamples/tree/master/TwoPlaneCross)
 - [Outdoor Air Conditioner Block sample](https://github.com/RengaSoftware/StyleTemplateSamples/tree/master/OutdoorAirConditionerUnit)
+- [Water Duct Heater](https://github.com/RengaSoftware/StyleTemplateSamples/tree/master/WaterDuctHeater)
 
 Reinforcement unit style templates:
 - [Reinforcing Mesh](https://github.com/RengaSoftware/StyleTemplateSamples/tree/master/ReinforcingMesh)

--- a/TwoPlaneCross/TwoPlaneCross.lua
+++ b/TwoPlaneCross/TwoPlaneCross.lua
@@ -85,7 +85,7 @@ function MakeDrawingGeometry(inletLength, outletLength, branch1Length, branch2Le
   
   geometry:AddGeometrySet2D(bodySymbol)
   geometry:AddGeometrySet2D(branch1Symbol, branch1SymbolPlacement)
-  geometry:AddGeometrySet2D(branch1Symbol, branch2SymbolPlacement)
+  geometry:AddGeometrySet2D(branch2Symbol, branch2SymbolPlacement)
 
   return geometry
 end


### PR DESCRIPTION
Fixed:

- synchronize the Gas Stove script with the same script from the STDL SDK
- synchronize the Outdoor air conditioner unit parameters with the parameters for the same script from the STDL SDK
- add a link to the Water duct heater sample to the Readme.md file
- fixed a typo in the Two plane cross script